### PR TITLE
Reduce hard coding in SCSS and allow images to be sourced from /images instead of just the current path

### DIFF
--- a/assets/scss/common/_dark.scss
+++ b/assets/scss/common/_dark.scss
@@ -2,23 +2,24 @@
 
 // Source: https://material.io/design/color/dark-theme.html
 
-$body-bg-dark: $gray-900;
-$body-overlay-dark: darken($body-bg-dark, 2.5%);
+$body-bg-dark: $gray-900 !default;
+$body-overlay-dark: darken($body-bg-dark, 2.5%) !default;
+$background-color: $body-bg-dark !default;
 
 /*
 $border-dark: darken($body-bg-dark, 2.5%);
 */
-$border-dark: $gray-800;
-$body-color-dark: $gray-300;
-$dots-dark: darken($body-color-dark, 50%);
+$border-dark: $gray-800 !default;
+$body-color-dark: $gray-300 !default;
+$dots-dark: darken($body-color-dark, 50%) !default;
 
-$link-color-dark: $blue-300;
-$button-color-dark: $link-color-dark;
-$focus-color-dark: lighten($link-color-dark, 2.5%);
+$link-color-dark: $blue-300 !default;
+$button-color-dark: $link-color-dark !default;
+$focus-color-dark: lighten($link-color-dark, 2.5%) !default;
 
-$navbar-dark-color:                 $body-color-dark;
-$navbar-dark-hover-color:           $link-color-dark;
-$navbar-dark-active-color:          $link-color-dark;
+$navbar-dark-color:                 $body-color-dark !default;
+$navbar-dark-hover-color:           $link-color-dark !default;
+$navbar-dark-active-color:          $link-color-dark !default;
 
 /** Theme styles */
 
@@ -83,7 +84,7 @@ $navbar-dark-active-color:          $link-color-dark;
 
 [data-dark-mode] body .navbar,
 [data-dark-mode] body .doks-subnavbar {
-  background-color: rgba(33, 37, 41, 0.95);
+  background-color: $background-color;
   border-bottom: 1px solid $border-dark;
 }
 

--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -46,6 +46,7 @@ body.docs {
 
 @include media-breakpoint-up(md) {
   body {
+    color: $body-color;
     font-size: $font-size-md;
 
     /*

--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -63,8 +63,8 @@ $navbar-light-toggler-icon-bg: none;
 //
 // Settings for the `<body>` element.
 
-$body-bg:                   $white;
-$body-color:                $black;
+$body-bg:                   $white !default;
+$body-color:                $black !default;
 
 // Links
 //
@@ -139,7 +139,7 @@ $navbar-padding-x:                  null;
 
 $navbar-nav-link-padding-x:         0.5rem;
 
-$navbar-light-color:                $black;
+$navbar-light-color:                $body-color;
 $navbar-light-hover-color:          $primary;
 $navbar-light-active-color:         $primary;
 
@@ -168,20 +168,20 @@ $dropdown-config: (
   layout-type: normal,
   layout-width: normal,
   layout-alignment: align,
-  background-color: $white,
+  background-color: $body-bg,
   border-radius: 4,
   border-width: 1,
-  border-color: $gray-200,
+  border-color: $body-bg,
   box-shadow: none,
   branding-position: bottom,
   spacing: normal,
   include-desc: yes,
-  background-category-header: $white,
+  background-category-header: $body-bg,
   font-size: normal,
-  header-color: $black,
-  title-color: $black,
-  subtitle-color: $black,
-  text-color: $black,
+  header-color: $body-color,
+  title-color: $body-color,
+  subtitle-color: $body-color,
+  text-color: $body-color,
   highlight-color: $purple,
   highlight-opacity: 0.1,
   highlight-type: underline

--- a/assets/scss/components/_alerts.scss
+++ b/assets/scss/components/_alerts.scss
@@ -1,3 +1,5 @@
+$alert-background: $beige !default;
+
 .alert {
   font-family: $font-family-monospace;
   font-size: $font-size-sm;
@@ -16,7 +18,7 @@
 }
 
 .alert-doks {
-  background: $beige;
+  background: $alert-background;
   color: $black;
 }
 

--- a/assets/scss/components/_search.scss
+++ b/assets/scss/components/_search.scss
@@ -58,7 +58,7 @@
 
 .suggestion__title {
   font-weight: $headings-font-weight;
-  color: $black;
+  color: $body-color;
 }
 
 .suggestion__description,

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -140,7 +140,7 @@ button#doks-versions {
 
 .header-bar {
   border-top: 4px solid;
-  border-image-source: linear-gradient(90deg, $primary, #8ed6fb 50%, #d32e9d);
+  border-image-source: linear-gradient(90deg, $primary, $secondary);
   border-image-slice: 1;
 }
 
@@ -317,7 +317,7 @@ button#doks-versions {
 }
 
 .algolia-autocomplete .algolia-docsearch-suggestion--category-header {
-  color: $black;
+  color: $body-color;
 }
 
 .algolia-autocomplete .algolia-docsearch-suggestion--title {

--- a/layouts/partials/content/card-image.html
+++ b/layouts/partials/content/card-image.html
@@ -4,6 +4,11 @@
 {{ end -}}
 
 {{ $image := .Resources.GetMatch (printf "**%s" (index .Params.images 0)) }}
+
+{{ if not $image -}}
+{{ $image = resources.Get (printf "%s%s" "images/" (index .Params.images 0)) }}
+{{ end -}}
+
 {{ if not $image -}}
   {{ $image = resources.Get (printf "%s%s" "images/" site.Params.defaultImage) }}
 {{ end -}}

--- a/layouts/partials/content/card-image.html
+++ b/layouts/partials/content/card-image.html
@@ -4,7 +4,6 @@
 {{ end -}}
 
 {{ $image := .Resources.GetMatch (printf "**%s" (index .Params.images 0)) }}
-
 {{ if not $image -}}
 {{ $image = resources.Get (printf "%s%s" "images/" (index .Params.images 0)) }}
 {{ end -}}
@@ -12,6 +11,16 @@
 {{ if not $image -}}
   {{ $image = resources.Get (printf "%s%s" "images/" site.Params.defaultImage) }}
 {{ end -}}
+
+{{ if eq $image.MediaType.SubType "svg" }}
+
+<img
+  class="card-img-top img-fluid lazyload blur-up"
+  src="{{ $image.Permalink }}"
+  data-src="{{ $image.Permalink }}"
+  alt="{{ .Title }}">
+
+{{ else }}
 
 {{ $webp := printf "%s%s" $fillImage " webp" }}
 {{ $image = $image.Resize $webp}}
@@ -25,3 +34,5 @@
   width="{{ $image.Width }}"
   height="{{ $image.Height }}"
   alt="{{ .Title }}">
+
+{{ end -}}

--- a/layouts/partials/content/figure.html
+++ b/layouts/partials/content/figure.html
@@ -5,6 +5,9 @@
 
 {{ $image := .Resources.GetMatch (printf "**%s" (index .Params.images 0)) }}
 {{ if not $image -}}
+{{ $image = resources.Get (printf "%s%s" "images/" (index .Params.images 0)) }}
+{{ end -}}
+{{ if not $image -}}
   {{ $image = resources.Get (printf "%s%s" "images/" site.Params.defaultImage) }}
 {{ end -}}
 

--- a/layouts/partials/content/figure.html
+++ b/layouts/partials/content/figure.html
@@ -11,6 +11,10 @@
   {{ $image = resources.Get (printf "%s%s" "images/" site.Params.defaultImage) }}
 {{ end -}}
 
+{{ if eq $image.MediaType.SubType "svg" }}
+  <img class="img-fluid lazyload blur-up" src="{{ $image.Permalink }}" data-src="{{ $image.Permalink }}" alt="{{ .Title }}">
+{{ else }}
+
 {{ $image = $image.Fill $fillImage }}
 {{ $lqip := $image.Resize site.Params.lqipWidth -}}
 
@@ -37,4 +41,6 @@
   </figure>
 {{ else -}}
   <img class="img-fluid lazyload blur-up" src="{{ $lqip.Permalink }}" data-src="{{ $image.Permalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}" alt="{{ .Title }}">
+{{ end -}}
+
 {{ end -}}

--- a/layouts/partials/content/image.html
+++ b/layouts/partials/content/image.html
@@ -6,6 +6,10 @@
   {{ $image = resources.Get (printf "%s%s" "images/" site.Params.defaultImage) }}
 {{ end -}}
 
+{{ if eq $image.MediaType.SubType "svg" }}
+  <img class="img-fluid lazyload blur-up" src="{{ $image.Permalink }}" data-src="{{ $image.Permalink }}" alt="{{ .Title }}">
+{{ else }}
+
 {{ $image = $image.Fill site.Params.fillImage }}
 {{ $lqip := $image.Resize site.Params.lqipWidth -}}
 
@@ -32,4 +36,6 @@
   </figure>
 {{ else -}}
   <img class="img-fluid lazyload blur-up" src="{{ $lqip.Permalink }}" data-src="{{ $image.Permalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}" alt="{{ .Title }}">
+{{ end -}}
+
 {{ end -}}

--- a/layouts/partials/content/image.html
+++ b/layouts/partials/content/image.html
@@ -1,5 +1,8 @@
 {{ $image := .Resources.GetMatch (printf "**%s" (index .Params.images 0)) }}
 {{ if not $image -}}
+{{ $image = resources.Get (printf "%s%s" "images/" (index .Params.images 0)) }}
+{{ end -}}
+{{ if not $image -}}
   {{ $image = resources.Get (printf "%s%s" "images/" site.Params.defaultImage) }}
 {{ end -}}
 

--- a/layouts/partials/head/opengraph.html
+++ b/layouts/partials/head/opengraph.html
@@ -36,7 +36,11 @@
 
 {{ with $.Params.images -}}
   {{ range first 6 . -}}
-  <meta property="og:image" content="{{ $.Permalink }}{{ . }}">
+  {{ $image := $.Resources.GetMatch (printf "**%s" . ) }}
+  {{ if not $image -}}
+  {{ $image = resources.Get (printf "%s%s" "images/" . ) }}
+  {{ end -}}
+  <meta property="og:image" content="{{ $image.Permalink }}">
   {{ end -}}
 {{ else -}}
   {{ $images := $.Resources.ByType "image" -}}

--- a/layouts/partials/head/twitter_cards.html
+++ b/layouts/partials/head/twitter_cards.html
@@ -4,7 +4,13 @@
 <meta name="twitter:title" content="{{ .Title }}">
 <meta name="twitter:description" content="{{ .Description }}">
 {{ with $.Params.images -}}
-  <meta name="twitter:image" content="{{ $.Permalink }}{{ index . 0 }}">
+  {{ range first 6 . -}}
+    {{ $image := $.Resources.GetMatch (printf "**%s" . ) }}
+    {{ if not $image -}}
+      {{ $image = resources.Get (printf "%s%s" "images/" . ) }}
+    {{ end -}}
+    <meta name="twitter:image" content="{{ $image.Permalink }}">
+  {{ end -}}
 {{ else -}}
   {{ $images := $.Resources.ByType "image" -}}
   {{ $featured := $images.GetMatch "*feature*" -}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "exec-bin": "^1.0.0",
         "flexsearch": "^0.7.21",
         "highlight.js": "^11.5",
-        "hugo-installer": "^3.1",
+        "hugo-installer": ">=4.0.1",
         "instant.page": "^5.1",
         "katex": "^0.16",
         "lazysizes": "^5.3",
@@ -1863,51 +1863,45 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
+      "integrity": "sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
     "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dev": true,
       "dependencies": {
-        "defer-to-connect": "^2.0.0"
+        "defer-to-connect": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       }
     },
     "node_modules/@types/cacheable-request": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-      "integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "dev": true,
       "dependencies": {
         "@types/http-cache-semantics": "*",
-        "@types/keyv": "*",
+        "@types/keyv": "^3.1.4",
         "@types/node": "*",
-        "@types/responselike": "*"
+        "@types/responselike": "^1.0.0"
       }
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
-      "dev": true
-    },
-    "node_modules/@types/json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==",
       "dev": true
     },
     "node_modules/@types/keyv": {
@@ -1926,9 +1920,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
-      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -1974,16 +1968,31 @@
       }
     },
     "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
       "dev": true,
       "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/aggregate-error/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ajv": {
@@ -2383,9 +2392,9 @@
       "dev": true
     },
     "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
+      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==",
       "dev": true,
       "engines": {
         "node": ">=10.6.0"
@@ -2419,6 +2428,27 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2539,12 +2569,30 @@
       }
     },
     "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clean-stack/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/clipboard": {
@@ -2582,12 +2630,15 @@
       }
     },
     "node_modules/clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "dev": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/color-convert": {
@@ -2618,19 +2669,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/compress-brotli": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
-      "integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-buffer": "~3.0.0",
-        "json-buffer": "~3.0.1"
-      },
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/concat-map": {
@@ -2961,34 +2999,56 @@
       }
     },
     "node_modules/del": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
-      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-7.0.0.tgz",
+      "integrity": "sha512-tQbV/4u5WVB8HMJr08pgw0b6nG4RGt/tj+7Numvq+zqcvUFeMaIWWOUFltiU+6go8BSO2/ogsB4EasDaj0y68Q==",
       "dev": true,
       "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
+        "globby": "^13.1.2",
+        "graceful-fs": "^4.2.10",
+        "is-glob": "^4.0.3",
+        "is-path-cwd": "^3.0.0",
+        "is-path-inside": "^4.0.0",
+        "p-map": "^5.5.0",
         "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
+        "slash": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del/node_modules/globby": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+      "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/del/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delegate": {
@@ -3538,6 +3598,15 @@
       "integrity": "sha512-W7cHV7Hrwjid6lWmy0IhsWDFQboWSng25U3VVywpHOTJnnAZNPScog67G+cVpeX9f7yDD21ih0WDrMMT+JoaYg==",
       "dev": true
     },
+    "node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -3929,28 +3998,41 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.5",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
-      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.4.1.tgz",
+      "integrity": "sha512-Sz1ojLt4zGNkcftIyJKnulZT/yEDvifhUjccHA8QzOuTgPs/+njXYNMFE3jR4/2OODQSSbH8SdnoLCkbh41ieA==",
       "dev": true,
       "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "@types/cacheable-request": "^6.0.2",
+        "cacheable-lookup": "^6.0.4",
         "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
+        "form-data-encoder": "^2.1.0",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
       },
       "engines": {
-        "node": ">=10.19.0"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -4056,10 +4138,13 @@
       }
     },
     "node_modules/hpagent": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
-      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.0.0.tgz",
+      "integrity": "sha512-SCleE2Uc1bM752ymxg8QXYGW0TWtAV4ZW3TqH1aOnyi6T6YW2xadCcclm5qeVjvMvfQ2RKNtZxO7uVb9CTPt1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/html-tags": {
       "version": "3.2.0",
@@ -4080,31 +4165,31 @@
       "dev": true
     },
     "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
       "dev": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
+        "resolve-alpn": "^1.2.0"
       },
       "engines": {
         "node": ">=10.19.0"
       }
     },
     "node_modules/hugo-installer": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hugo-installer/-/hugo-installer-3.1.0.tgz",
-      "integrity": "sha512-E3yc8m1NRZBROOx0tx5WtUfAa9EcBbjbM4YSfy3KLGXQfHXIpbfD3oQ5YIKvih8aKuyyRtKzBZIdiOHfWAvvtg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hugo-installer/-/hugo-installer-4.0.1.tgz",
+      "integrity": "sha512-pkp1RO7+ekQ0vw1aqgBMK+dD2dqioIWVbwWKsJsKLOpzfFc78gK68Cweoi/g+CftoiMFO7cyGx/2MgkHCMqaLQ==",
       "dev": true,
       "dependencies": {
         "decompress": "4.2.x",
-        "del": "6.0.x",
-        "got": "11.8.x",
-        "hpagent": "0.1.x",
+        "del": "7.0.x",
+        "got": "12.4.x",
+        "hpagent": "1.0.x",
         "object-path": "0.11.x",
         "semver": "7.3.x",
-        "yargs": "16.2.x"
+        "yargs": "17.5.x"
       },
       "bin": {
         "hugo-installer": "bin/hugo-installer.js"
@@ -4319,21 +4404,27 @@
       }
     },
     "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
+      "integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -4488,12 +4579,11 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.2.tgz",
-      "integrity": "sha512-kn8WmodVBe12lmHpA6W8OY7SNh6wVR+Z+wZESF4iF5FCazaVXGWOtnbnvX0tMQ1bO+/TmOD9LziuYMvrIIs0xw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "dev": true,
       "dependencies": {
-        "compress-brotli": "^1.3.8",
         "json-buffer": "3.0.1"
       }
     },
@@ -4604,12 +4694,15 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -4975,9 +5068,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.6.tgz",
-      "integrity": "sha512-LAy/HZnLADOVkVPubaxHDft29booGglPFDr2Hw0J1AercRh01UiVFm++KMDnJeH9sHgNB4hsXPii7Sgym/sTbw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
       "dev": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -5130,12 +5223,12 @@
       }
     },
     "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12.20"
       }
     },
     "node_modules/p-limit": {
@@ -5166,15 +5259,15 @@
       }
     },
     "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
       "dev": true,
       "dependencies": {
-        "aggregate-error": "^3.0.0"
+        "aggregate-error": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5409,33 +5502,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/postcss-cli/node_modules/yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/postcss-cli/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/postcss-load-config": {
@@ -5953,12 +6019,18 @@
       }
     },
     "node_modules/responselike": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dev": true,
       "dependencies": {
-        "lowercase-keys": "^2.0.0"
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reusify": {
@@ -6969,21 +7041,21 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
       "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
@@ -6993,6 +7065,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yauzl": {
@@ -8281,42 +8362,36 @@
       "peer": true
     },
     "@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
+      "integrity": "sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==",
       "dev": true
     },
     "@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
       "dev": true,
       "requires": {
-        "defer-to-connect": "^2.0.0"
+        "defer-to-connect": "^2.0.1"
       }
     },
     "@types/cacheable-request": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
-      "integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "dev": true,
       "requires": {
         "@types/http-cache-semantics": "*",
-        "@types/keyv": "*",
+        "@types/keyv": "^3.1.4",
         "@types/node": "*",
-        "@types/responselike": "*"
+        "@types/responselike": "^1.0.0"
       }
     },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
-      "dev": true
-    },
-    "@types/json-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==",
       "dev": true
     },
     "@types/keyv": {
@@ -8335,9 +8410,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
-      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -8375,13 +8450,21 @@
       "requires": {}
     },
     "aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
       "dev": true,
       "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+          "dev": true
+        }
       }
     },
     "ajv": {
@@ -8642,9 +8725,9 @@
       "dev": true
     },
     "cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz",
+      "integrity": "sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==",
       "dev": true
     },
     "cacheable-request": {
@@ -8669,6 +8752,21 @@
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        },
+        "responselike": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+          "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+          "dev": true,
+          "requires": {
+            "lowercase-keys": "^2.0.0"
           }
         }
       }
@@ -8748,10 +8846,21 @@
       }
     },
     "clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+          "dev": true
+        }
+      }
     },
     "clipboard": {
       "version": "2.0.11",
@@ -8785,9 +8894,9 @@
       }
     },
     "clone-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
@@ -8819,16 +8928,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
-    },
-    "compress-brotli": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
-      "integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
-      "dev": true,
-      "requires": {
-        "@types/json-buffer": "~3.0.0",
-        "json-buffer": "~3.0.1"
-      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -9082,25 +9181,38 @@
       }
     },
     "del": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
-      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-7.0.0.tgz",
+      "integrity": "sha512-tQbV/4u5WVB8HMJr08pgw0b6nG4RGt/tj+7Numvq+zqcvUFeMaIWWOUFltiU+6go8BSO2/ogsB4EasDaj0y68Q==",
       "dev": true,
       "requires": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
+        "globby": "^13.1.2",
+        "graceful-fs": "^4.2.10",
+        "is-glob": "^4.0.3",
+        "is-path-cwd": "^3.0.0",
+        "is-path-inside": "^4.0.0",
+        "p-map": "^5.5.0",
         "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
+        "slash": "^4.0.0"
       },
       "dependencies": {
+        "globby": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+          "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+          "dev": true,
+          "requires": {
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.11",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^4.0.0"
+          }
+        },
         "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
           "dev": true
         }
       }
@@ -9517,6 +9629,12 @@
       "integrity": "sha512-W7cHV7Hrwjid6lWmy0IhsWDFQboWSng25U3VVywpHOTJnnAZNPScog67G+cVpeX9f7yDD21ih0WDrMMT+JoaYg==",
       "dev": true
     },
+    "form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true
+    },
     "formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -9819,22 +9937,31 @@
       }
     },
     "got": {
-      "version": "11.8.5",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
-      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.4.1.tgz",
+      "integrity": "sha512-Sz1ojLt4zGNkcftIyJKnulZT/yEDvifhUjccHA8QzOuTgPs/+njXYNMFE3jR4/2OODQSSbH8SdnoLCkbh41ieA==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "@types/cacheable-request": "^6.0.2",
+        "cacheable-lookup": "^6.0.4",
         "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
+        "form-data-encoder": "^2.1.0",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
@@ -9908,9 +10035,9 @@
       }
     },
     "hpagent": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
-      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.0.0.tgz",
+      "integrity": "sha512-SCleE2Uc1bM752ymxg8QXYGW0TWtAV4ZW3TqH1aOnyi6T6YW2xadCcclm5qeVjvMvfQ2RKNtZxO7uVb9CTPt1A==",
       "dev": true
     },
     "html-tags": {
@@ -9926,28 +10053,28 @@
       "dev": true
     },
     "http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
       "dev": true,
       "requires": {
         "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
+        "resolve-alpn": "^1.2.0"
       }
     },
     "hugo-installer": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hugo-installer/-/hugo-installer-3.1.0.tgz",
-      "integrity": "sha512-E3yc8m1NRZBROOx0tx5WtUfAa9EcBbjbM4YSfy3KLGXQfHXIpbfD3oQ5YIKvih8aKuyyRtKzBZIdiOHfWAvvtg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hugo-installer/-/hugo-installer-4.0.1.tgz",
+      "integrity": "sha512-pkp1RO7+ekQ0vw1aqgBMK+dD2dqioIWVbwWKsJsKLOpzfFc78gK68Cweoi/g+CftoiMFO7cyGx/2MgkHCMqaLQ==",
       "dev": true,
       "requires": {
         "decompress": "4.2.x",
-        "del": "6.0.x",
-        "got": "11.8.x",
-        "hpagent": "0.1.x",
+        "del": "7.0.x",
+        "got": "12.4.x",
+        "hpagent": "1.0.x",
         "object-path": "0.11.x",
         "semver": "7.3.x",
-        "yargs": "16.2.x"
+        "yargs": "17.5.x"
       },
       "dependencies": {
         "semver": {
@@ -10102,15 +10229,15 @@
       "dev": true
     },
     "is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-3.0.0.tgz",
+      "integrity": "sha512-kyiNFFLU0Ampr6SDZitD/DwUo4Zs1nSdnygUBqsu3LooL00Qvb5j+UnvApUn/TTj1J3OuE6BTdQ5rudKmU2ZaA==",
       "dev": true
     },
     "is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
       "dev": true
     },
     "is-plain-obj": {
@@ -10228,12 +10355,11 @@
       }
     },
     "keyv": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.2.tgz",
-      "integrity": "sha512-kn8WmodVBe12lmHpA6W8OY7SNh6wVR+Z+wZESF4iF5FCazaVXGWOtnbnvX0tMQ1bO+/TmOD9LziuYMvrIIs0xw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
       "dev": true,
       "requires": {
-        "compress-brotli": "^1.3.8",
         "json-buffer": "3.0.1"
       }
     },
@@ -10329,9 +10455,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true
     },
     "lru-cache": {
@@ -10593,9 +10719,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.6.tgz",
-      "integrity": "sha512-LAy/HZnLADOVkVPubaxHDft29booGglPFDr2Hw0J1AercRh01UiVFm++KMDnJeH9sHgNB4hsXPii7Sgym/sTbw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
       "dev": true,
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
@@ -10704,9 +10830,9 @@
       }
     },
     "p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true
     },
     "p-limit": {
@@ -10728,12 +10854,12 @@
       }
     },
     "p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
       "dev": true,
       "requires": {
-        "aggregate-error": "^3.0.0"
+        "aggregate-error": "^4.0.0"
       }
     },
     "p-try": {
@@ -10886,27 +11012,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
           "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "17.5.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-          "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
       }
@@ -11288,12 +11393,12 @@
       "dev": true
     },
     "responselike": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^2.0.0"
+        "lowercase-keys": "^3.0.0"
       }
     },
     "reusify": {
@@ -12070,18 +12175,26 @@
       "dev": true
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
       "dev": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.0.0"
+      },
+      "dependencies": {
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
       }
     },
     "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "exec-bin": "^1.0.0",
     "flexsearch": "^0.7.21",
     "highlight.js": "^11.5",
-    "hugo-installer": "^3.1",
+    "hugo-installer": ">=4.0.1",
     "instant.page": "^5.1",
     "katex": "^0.16",
     "lazysizes": "^5.3",
@@ -66,6 +66,6 @@
     "stylelint-config-standard-scss": "^4.0"
   },
   "otherDependencies": {
-    "hugo": "0.101.0"
+    "hugo": "0.107.0"
   }
 }


### PR DESCRIPTION
## Summary

Reduce hard coding in SCSS
Allow images to be sourced from /images instead of just the current path

## Basic example

[Example using the new updates](view-source:https://diving.otoh.org/incident-reports/2022-08-19-freedive/)

## Motivation

Allows for easier customisation of CSS
Allows for common images (or all images if the user prefers) to be sourced from the images directory.

## Checks

- [X] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [X] Supports all screen sizes (if relevant)
- [X] Supports both light and dark mode (if relevant)
- [X] Passes `npm run test`
