### PR TITLE
Fix build:preview, add server:preview, update hugo

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "exec-bin node_modules/.bin/hugo/hugo server --bind=0.0.0.0 --disableFastRender",
     "prebuild": "npm run clean",
     "build": "exec-bin node_modules/.bin/hugo/hugo --gc --minify",
-    "build:preview": "npm run build -D -F",
+    "build:preview": "exec-bin node_modules/.bin/hugo/hugo --gc --minify -D -F",
     "clean": "shx rm -rf public resources",
     "clean:install": "shx rm -rf package-lock.json node_modules ",
     "lint": "npm run -s lint:scripts && npm run -s lint:styles && npm run -s lint:markdown",
@@ -29,6 +29,7 @@
     "lint:markdown": "markdownlint-cli2 \"*.md\" \"content/**/*.md\"",
     "lint:markdown-fix": "markdownlint-cli2-fix \"*.md\" \"content/**/*.md\"",
     "server": "exec-bin node_modules/.bin/hugo/hugo server",
+    "server:preview": "exec-bin node_modules/.bin/hugo/hugo server -D -F",
     "test": "npm run -s lint",
     "env": "env",
     "precheck": "npm version",
@@ -66,6 +67,6 @@
     "stylelint-config-standard-scss": "^4.0"
   },
   "otherDependencies": {
-    "hugo": "0.107.0"
+    "hugo": "0.109.0"
   }
 }


### PR DESCRIPTION
## Summary

`build:preview` wrapped into a call to hugo which did not involve `-D` or `-F`. Fix this.

Add `server:preview` as it's useful.

Update hugo to 109

## Basic example

N/A

## Motivation

Fix a defect, add a useful feature, update hugo for features and bugs

## Checks

- [X] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [N/A] Supports all screen sizes (if relevant)
- [N/A] Supports both light and dark mode (if relevant)
- [X] Passes `npm run test`
