### PR TITLE
fix: index is break if a content contain certain characters

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -78,20 +78,6 @@ Source:
 
   // Not yet supported: https://github.com/nextapps-de/flexsearch#complex-documents
 
-  /*
-  var docs = [
-    {{ range $index, $page := (where .Site.Pages "Section" "docs") -}}
-      {
-        id: {{ $index }},
-        href: "{{ .Permalink }}",
-        title: {{ .Title | jsonify }},
-        description: {{ .Params.description | jsonify }},
-        content: {{ .Content | jsonify }}
-      },
-    {{ end -}}
-  ];
-  */
-
   // https://discourse.gohugo.io/t/range-length-or-last-element/3803/2
 
   {{ $list := slice }}


### PR DESCRIPTION
Resolve this discussion : https://github.com/h-enk/doks/discussions/1078

## Summary

This code comment is interpreted anyway. Generates an error in the JS file when opening the comment if the characters `*/` are present. 

This can happen on documentation that includes code in markdown format, as in the [discussion here](https://github.com/h-enk/doks/discussions/1078).

## Basic example

Create a page with a code in markdown like : 

```
borgwarehouse ALL=(ALL) NOPASSWD: /usr/sbin/userdel -rf [[\:xdigit\:]]*
borgwarehouse ALL=(ALL) NOPASSWD: /usr/sbin/useradd -d /var/borgwarehouse/[[\:xdigit\:]]* -s /bin/bash -m --badname [[\:xdigit\:]]*
borgwarehouse ALL=(ALL) NOPASSWD: /usr/bin/mkdir -p /var/borgwarehouse/[[\:xdigit\:]]*/repos/repo[[\:digit\:]]*, /usr/bin/mkdir -p /var/borgwarehouse/[[\:xdigit\:]]*/.ssh
borgwarehouse ALL=(ALL) NOPASSWD: /usr/bin/touch /var/borgwarehouse/[[\:xdigit\:]]*/.ssh/authorized_keys
borgwarehouse ALL=(ALL) NOPASSWD: /usr/bin/chmod -R 750 /var/borgwarehouse/[[\:xdigit\:]]*, /usr/bin/chmod 600 /var/borgwarehouse/[[\:xdigit\:]]*/.ssh/authorized_keys
borgwarehouse ALL=(ALL) NOPASSWD: /usr/bin/chown -R [[\:xdigit\:]]*\:borgwarehouse /var/borgwarehouse/[[\:xdigit\:]]*
borgwarehouse ALL=(ALL) NOPASSWD: /usr/bin/tee /var/borgwarehouse/[[\:xdigit\:]]*/.ssh/authorized_keys
borgwarehouse ALL=(ALL) NOPASSWD: /usr/bin/sed -ri s|*|g /var/borgwarehouse/[[\:xdigit\:]]*/.ssh/authorized_keys
borgwarehouse ALL=(ALL) NOPASSWD: /usr/bin/du -s -- [[\:xdigit\:]]*
```

Build doks. The file `index.min.XXXX.js` is now broken because of the comment section is open and not close.

## Motivation
Break index in my website : https://borgwarehouse.com/

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Passes `npm run test`
