### PR TITLE
feat: allow custom kroki host

### DIFF
--- a/.changeset/large-peas-share.md
+++ b/.changeset/large-peas-share.md
@@ -1,0 +1,5 @@
+---
+"doks": patch
+---
+
+Allow custom kroki host

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -78,6 +78,8 @@ mainSections = ["docs"]
   docsRepoBranch = "main" # main (default), master, or <branch name>
   docsRepoSubPath = "" # "" (none, default) or <sub path>
 
+  krokiURL = "https://kroki.io" # "https://kroki.io" (default) or custom URL like http://localhost:8000.
+
   # SCSS colors
   # backGround = "yellowgreen"
   ## Dark theme


### PR DESCRIPTION
See https://github.com/gethyas/doks-core/pull/102. Body copied below.

## Summary

Allow users to provide a custom Kroki URL instead of hard-coding
https://kroki.io.

## Basic example

In `params.toml`, users of this theme can set a custom Kroki URL, such
as a local instance:

```toml
[doks]
    krokiURL = "http://localhost:8000"
```

I tried my best to keep proper backwards compatibility should users not
provide this configuration key *at all*—see the diff. Should this not be
acceptable, please let me know.

## Motivation

At times, the upstream kroki.io service may run into resource exhaustion.
This can be due to a high volume of requests or a temporary outage.
During an automated build, this isn't so bad—caches should exist and
therefore not hit Kroki as often.

However, especially during the writing phase of
documentation, where fast iteration is often needed, it is not helpful
when the upstream service runs into said resource exhaustion and responds
with an unhelpful "Bad Request" error.

This issue is known and understood by the Kroki team; the fix is to run
your own instance.[^1]

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`

[^1]: https://kroki.zulipchat.com/#narrow/stream/232085-users/topic/kroki.2Eio.20returns.20400.20on.20Mermaid.20diagrams
